### PR TITLE
[codex] Add Pug class extraction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Works similarly to the [eCSStractor](https://packagecontrol.io/packages/eCSStrac
 - Extracting class names from HTML to a new stylesheet file, a scratch file, or your clipboard.
 - Specifying the target language of that new file: CSS, LESS, SCSS, SASS, Stylus.
 - Using BEM-specific nesting.
-- Working with HTML, PHP, JSX, Vue and other XML-like files.
+- Working with HTML, PHP, JSX, Vue, Pug and other XML-like files.
 
 You can tweak the plugin settings in *Preferences / Settings | ECSStractor*.
 

--- a/src/main/kotlin/extract/css/actions/ExtractCSSAction.kt
+++ b/src/main/kotlin/extract/css/actions/ExtractCSSAction.kt
@@ -43,17 +43,7 @@ class ExtractCSSAction : AnAction() {
         val classNames = mutableSetOf<String>()
         val elements = extractElementForVisiting(e, file)
         for (element in elements) {
-            element.acceptChildren(object : XmlRecursiveElementWalkingVisitor() {
-                override fun visitXmlAttribute(attribute: XmlAttribute) {
-                    val name = attribute.name
-                    if (name == "class" || name == "className") {
-                        val value = attribute.valueElement ?: return
-                        if (value.firstChild is JSEmbeddedContent) return
-
-                        classNames.addAll(attribute.value?.split(" ")?.filter(String::isNotBlank) ?: emptyList())
-                    }
-                }
-            })
+            classNames.addAll(collectClassNames(element))
         }
 
         return classNames.toList()
@@ -118,6 +108,62 @@ class ExtractCSSAction : AnAction() {
         e.presentation.isEnabledAndVisible =
             (file is XmlFile || file is JSFile) && e.project != null
     }
+}
+
+fun collectClassNames(element: PsiElement): Set<String> {
+    val classNames = linkedSetOf<String>()
+
+    element.accept(object : PsiRecursiveElementWalkingVisitor() {
+        override fun visitElement(element: PsiElement) {
+            if (element is XmlAttribute) classNames.addAll(collectXmlAttributeClassNames(element))
+            super.visitElement(element)
+        }
+    })
+
+    if (isPugLikeElement(element)) {
+        classNames.addAll(collectPugClassNamesFromText(element.text))
+    }
+
+    return classNames
+}
+
+private fun collectXmlAttributeClassNames(attribute: XmlAttribute): List<String> {
+    val name = attribute.name
+    if (name != "class" && name != "className") return emptyList()
+
+    val value = attribute.valueElement ?: return emptyList()
+    if (value.firstChild is JSEmbeddedContent) return emptyList()
+
+    return attribute.value?.split(" ")?.filter(String::isNotBlank) ?: emptyList()
+}
+
+fun collectPugClassNamesFromText(text: String): List<String> {
+    val result = linkedSetOf<String>()
+    val attributeRegex = Regex("""(?:class|className)\s*=\s*(['"])(.*?)\1""")
+    val shorthandRegex = Regex("""\.([A-Za-z0-9_-]+)""")
+
+    text.lineSequence().forEach { rawLine ->
+        val line = rawLine.trim()
+        if (line.isBlank() || line.startsWith("//")) return@forEach
+
+        attributeRegex.findAll(line).forEach { match ->
+            result.addAll(match.groupValues[2].split(" ").filter(String::isNotBlank))
+        }
+
+        val shorthandArea = line.takeWhile { it != ' ' && it != '\t' && it != '(' && it != '=' && it != '!' }
+        shorthandRegex.findAll(shorthandArea).forEach { match ->
+            result.add(match.groupValues[1])
+        }
+    }
+
+    return result.toList()
+}
+
+private fun isPugLikeElement(element: PsiElement): Boolean {
+    val file = element.containingFile ?: return false
+    val extension = file.virtualFile?.extension?.lowercase()
+    val languageId = file.language.id.lowercase()
+    return extension == "pug" || extension == "jade" || languageId == "jade"
 }
 
 class BEMBlock(val name: String) {

--- a/src/test/kotlin/com/github/anstarovoyt/intellijextractcss/ExtractorTest.kt
+++ b/src/test/kotlin/com/github/anstarovoyt/intellijextractcss/ExtractorTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.extensions.PluginId
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import extract.css.actions.ExtractState
 import extract.css.actions.TargetLanguage
+import extract.css.actions.collectPugClassNamesFromText
 import extract.css.actions.generateContent
 import junit.framework.TestCase
 import org.junit.Test
@@ -195,6 +196,32 @@ class ExtractorTest : BasePlatformTestCase() {
               // .foo__element_modifier
               &_modifier
         """.trimIndent(), generateContent(state, listOf("foo__element_modifier"))
+        )
+    }
+
+    @Test
+    fun testCollectClassNamesFromPugShorthand() {
+        TestCase.assertEquals(
+            listOf("foo", "bar", "content", "content_theme_dark"),
+            collectPugClassNamesFromText(
+                """
+                    .foo.bar
+                    section.content.content_theme_dark
+                """.trimIndent()
+            )
+        )
+    }
+
+    @Test
+    fun testCollectClassNamesFromPugClassAttribute() {
+        TestCase.assertEquals(
+            listOf("foo", "bar", "baz"),
+            collectPugClassNamesFromText(
+                """
+                    div(class="foo bar")
+                    button(className="baz")
+                """.trimIndent()
+            )
         )
     }
 }


### PR DESCRIPTION
## What changed
- added support for extracting CSS classes from Pug templates
- extended extraction logic in `ExtractCSSAction` to recognize Pug class syntax alongside existing patterns
- added test coverage for the new Pug extraction behavior
- updated the README example to reflect supported extraction scenarios

## Why
Projects using Pug templates could not use the extraction flow for class names, even though the plugin already supported similar markup patterns. This change closes that gap and makes the feature work in mixed-template codebases.

## Impact
Users can now run class extraction on Pug markup without manual workarounds. This broadens template support while keeping the existing behavior unchanged for other file types.

## Validation
- reviewed the implementation in commit `2df5ea7`
- verified the diff includes production changes plus automated test coverage in `ExtractorTest`
- local branch is clean and synchronized with `origin/main`
